### PR TITLE
Remove duplicate tidwall/gjson import

### DIFF
--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -16,7 +16,6 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/tidwall/gjson"
 	"github.com/tidwall/sjson"
-	"github.com/tidwall/gjson"
 )
 
 const (


### PR DESCRIPTION
Noticed a `make` failure when building this package locally (due to duplicated `gjson` import). This MR removes the duplicate import.