### PR TITLE
feat: add Ollama think parameter and structured outputs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ This commit automatically rebases onto the latest llama-swap nightly.
   - `api/chat` (untested)
   - `api/embed`
   - `api/embeddings`
+- ✅ Enhanced Ollama API translation:
+  - Tool calling support (translates Ollama tool calls to/from OpenAI format)
+  - `think` parameter for extended thinking models (maps to OpenAI `reasoning_effort`)
+  - Structured outputs via `format` parameter (JSON schema support)
+  - Reasoning content mapping (OpenAI `reasoning_content` ↔ Ollama `thinking` field)
 
 ## How to install
 Use the original [Building from source](#building-from-source) instructions, and overwrite your installed llama-swap executable with the newly built one.

--- a/proxy/config/model_config.go
+++ b/proxy/config/model_config.go
@@ -38,6 +38,11 @@ type ModelConfig struct {
 
 	// override global setting
 	SendLoadingState *bool `yaml:"sendLoadingState"`
+
+	// ChatTemplateKwargs: default chat_template_kwargs to apply to all requests
+	// These are merged with request-level values, with request values taking precedence
+	// Useful for setting model-specific defaults like enable_thinking for Qwen3
+	ChatTemplateKwargs map[string]any `yaml:"chatTemplateKwargs"`
 }
 
 func (m *ModelConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/proxy/config/model_config_test.go
+++ b/proxy/config/model_config_test.go
@@ -72,3 +72,35 @@ models:
 		assert.True(t, *config.Models["model2"].SendLoadingState)
 	}
 }
+
+func TestConfig_ChatTemplateKwargs(t *testing.T) {
+	content := `
+models:
+  qwen3-thinking:
+    cmd: path/to/cmd --port ${PORT}
+    chatTemplateKwargs:
+      enable_thinking: true
+  qwen3-no-thinking:
+    cmd: path/to/cmd --port ${PORT}
+    chatTemplateKwargs:
+      enable_thinking: false
+  model-no-kwargs:
+    cmd: path/to/cmd --port ${PORT}
+`
+	config, err := LoadConfigFromReader(strings.NewReader(content))
+	assert.NoError(t, err)
+
+	// Model with enable_thinking: true
+	kwargs1 := config.Models["qwen3-thinking"].ChatTemplateKwargs
+	assert.NotNil(t, kwargs1)
+	assert.Equal(t, true, kwargs1["enable_thinking"])
+
+	// Model with enable_thinking: false
+	kwargs2 := config.Models["qwen3-no-thinking"].ChatTemplateKwargs
+	assert.NotNil(t, kwargs2)
+	assert.Equal(t, false, kwargs2["enable_thinking"])
+
+	// Model without chatTemplateKwargs
+	kwargs3 := config.Models["model-no-kwargs"].ChatTemplateKwargs
+	assert.Nil(t, kwargs3)
+}

--- a/proxy/proxymanager.go
+++ b/proxy/proxymanager.go
@@ -639,6 +639,32 @@ func (pm *ProxyManager) proxyInferenceHandler(c *gin.Context) {
 		}
 	}
 
+	// Translate Ollama's "think" parameter to llama-server's "chat_template_kwargs"
+	// This allows OpenAI API clients to control thinking mode using the Ollama convention
+	if thinkResult := gjson.GetBytes(bodyBytes, "think"); thinkResult.Exists() {
+		thinkValue := thinkResult.Bool()
+		// Check if chat_template_kwargs already exists
+		if !gjson.GetBytes(bodyBytes, "chat_template_kwargs").Exists() {
+			bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs", map[string]interface{}{
+				"enable_thinking": thinkValue,
+			})
+			if err != nil {
+				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error setting chat_template_kwargs: %s", err.Error()))
+				return
+			}
+		} else {
+			// Merge with existing chat_template_kwargs
+			bodyBytes, err = sjson.SetBytes(bodyBytes, "chat_template_kwargs.enable_thinking", thinkValue)
+			if err != nil {
+				pm.sendErrorResponse(c, http.StatusInternalServerError, fmt.Sprintf("error setting enable_thinking: %s", err.Error()))
+				return
+			}
+		}
+		// Remove the original "think" parameter as llama-server doesn't understand it
+		bodyBytes, _ = sjson.DeleteBytes(bodyBytes, "think")
+		pm.proxyLogger.Debugf("<%s> translated think=%v to chat_template_kwargs.enable_thinking", realModelName, thinkValue)
+	}
+
 	c.Request.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
 
 	// dechunk it as we already have all the body bytes see issue #11


### PR DESCRIPTION
- Add 'think' parameter to OllamaChatRequest for controlling reasoning mode
- Translate 'think' to chat_template_kwargs.enable_thinking for llama-server
- Support JSON Schema objects in 'format' for structured outputs
- Handle 'think' parameter in OpenAI API path (/v1/chat/completions)
- Add comprehensive tests for new functionality

This enables Ollama API clients to control thinking/reasoning mode on models like Qwen3 by using the 'think: true/false' parameter, which gets translated to llama-server's chat_template_kwargs mechanism.