### PR TITLE
fix(ollama-api): bind tool responses without identifiers to pending tool calls

### DIFF
--- a/proxy/ollama_api.go
+++ b/proxy/ollama_api.go
@@ -1390,12 +1390,32 @@ func openAIRoleToOllama(role string) string {
 	}
 }
 
+// pendingToolCall tracks a tool call from the most recent assistant message so
+// tool responses that arrive without a usable tool_call_id can be bound to it.
+type pendingToolCall struct {
+	id       string
+	name     string
+	consumed bool
+}
+
 func ollamaMessagesToOpenAI(ollamaMsgs []OllamaMessage) []map[string]interface{} {
-	openAIMsgs := make([]map[string]interface{}, len(ollamaMsgs))
+	openAIMsgs := make([]map[string]interface{}, 0, len(ollamaMsgs))
+
+	// Tool calls from the most recent assistant message. Tool responses without
+	// an explicit tool_call_id are bound to these by function name, then by
+	// position. Some clients (e.g. Zed) send neither tool_call_id nor tool_name.
+	var pendingToolCalls []pendingToolCall
+
 	for i, msg := range ollamaMsgs {
 		openAIMsg := map[string]interface{}{
 			"role":    msg.Role,
 			"content": msg.Content,
+		}
+
+		// Any assistant message starts a new round; tool calls from earlier
+		// rounds must not capture later tool responses.
+		if msg.Role == "assistant" {
+			pendingToolCalls = nil
 		}
 
 		// Handle tool calls from assistant
@@ -1417,6 +1437,8 @@ func ollamaMessagesToOpenAI(ollamaMsgs []OllamaMessage) []map[string]interface{}
 				if toolID == "" {
 					toolID = fmt.Sprintf("call_%d_%d", i, validIndex)
 				}
+
+				pendingToolCalls = append(pendingToolCalls, pendingToolCall{id: toolID, name: tc.Function.Name})
 
 				// Default type to "function" if not provided
 				toolType := tc.Type
@@ -1442,19 +1464,55 @@ func ollamaMessagesToOpenAI(ollamaMsgs []OllamaMessage) []map[string]interface{}
 		// Handle tool role messages
 		// Support both OpenAI style (tool_call_id) and Ollama native style (tool_name)
 		if msg.Role == "tool" {
-			if msg.ToolCallID != "" {
-				openAIMsg["tool_call_id"] = msg.ToolCallID
-			} else if msg.ToolName != "" {
-				// Ollama native format uses tool_name instead of tool_call_id
-				// Generate a synthetic ID based on the tool name for OpenAI compatibility
-				openAIMsg["tool_call_id"] = fmt.Sprintf("call_%s_%d", msg.ToolName, i)
+			toolCallID := msg.ToolCallID
+			if toolCallID != "" {
+				// Explicit ID: consume the matching pending call so a later
+				// identifier-less response in this round can't re-use it.
+				for p := range pendingToolCalls {
+					if pendingToolCalls[p].id == toolCallID {
+						pendingToolCalls[p].consumed = true
+						break
+					}
+				}
 			}
+			if toolCallID == "" && msg.ToolName != "" {
+				// A function name is more information than ordinal position: it
+				// pairs correctly even when responses arrive out of order.
+				for p := range pendingToolCalls {
+					if !pendingToolCalls[p].consumed && pendingToolCalls[p].name == msg.ToolName {
+						toolCallID = pendingToolCalls[p].id
+						pendingToolCalls[p].consumed = true
+						break
+					}
+				}
+			}
+			if toolCallID == "" {
+				// Bind to the first unconsumed pending call by position.
+				for p := range pendingToolCalls {
+					if !pendingToolCalls[p].consumed {
+						toolCallID = pendingToolCalls[p].id
+						pendingToolCalls[p].consumed = true
+						break
+					}
+				}
+			}
+			if toolCallID == "" {
+				if msg.ToolName == "" {
+					// Nothing can bind this response (e.g. it answered a
+					// hallucinated call that was filtered out). A tool message
+					// without tool_call_id is invalid downstream, so drop it.
+					continue
+				}
+				// Named but unmatched: keep it with a synthetic ID.
+				toolCallID = fmt.Sprintf("call_%s_%d", msg.ToolName, i)
+			}
+			openAIMsg["tool_call_id"] = toolCallID
 			if msg.Content == "" {
 				openAIMsg["content"] = "null"
 			}
 		}
 
-		openAIMsgs[i] = openAIMsg
+		openAIMsgs = append(openAIMsgs, openAIMsg)
 	}
 	return openAIMsgs
 }
@@ -1577,7 +1635,7 @@ func validateToolRequest(req *OllamaChatRequest) error {
 	// Validate messages - be lenient for compatibility with various clients
 	// and to handle models that hallucinate invalid tool calls
 	//
-	// First pass: filter out invalid tool calls with empty function names
+	// Filter out invalid tool calls with empty function names
 	for i, msg := range req.Messages {
 		if msg.Role == "assistant" && len(msg.ToolCalls) > 0 {
 			validToolCalls := make([]OllamaToolCall, 0, len(msg.ToolCalls))
@@ -1592,17 +1650,8 @@ func validateToolRequest(req *OllamaChatRequest) error {
 		}
 	}
 
-	// Second pass: filter out tool response messages that have empty tool_name
-	// These correspond to the hallucinated tool calls we filtered above
-	validMessages := make([]OllamaMessage, 0, len(req.Messages))
-	for _, msg := range req.Messages {
-		// Skip tool responses with empty identifiers (responses to hallucinated tool calls)
-		if msg.Role == "tool" && msg.ToolCallID == "" && msg.ToolName == "" {
-			continue // Skip this message entirely
-		}
-		validMessages = append(validMessages, msg)
-	}
-	req.Messages = validMessages
+	// Tool responses without identifiers are bound to pending tool calls in
+	// ollamaMessagesToOpenAI; unbindable ones are dropped there.
 
 	return nil
 }

--- a/proxy/ollama_api_test.go
+++ b/proxy/ollama_api_test.go
@@ -707,3 +707,98 @@ func TestOllamaChatRequestWithThink(t *testing.T) {
 		})
 	}
 }
+
+// TestOllamaMessagesToOpenAIToolResponseBinding verifies how tool responses are
+// bound to the assistant's tool calls during Ollama -> OpenAI translation,
+// especially for clients that omit tool_call_id and/or tool_name.
+func TestOllamaMessagesToOpenAIToolResponseBinding(t *testing.T) {
+	call := func(id, name string) OllamaToolCall {
+		return OllamaToolCall{ID: id, Function: OllamaToolCallFunc{Name: name, Arguments: map[string]interface{}{}}}
+	}
+	asst := func(calls ...OllamaToolCall) OllamaMessage {
+		return OllamaMessage{Role: "assistant", ToolCalls: calls}
+	}
+	tool := func(id, name, content string) OllamaMessage {
+		return OllamaMessage{Role: "tool", ToolCallID: id, ToolName: name, Content: content}
+	}
+	user := OllamaMessage{Role: "user", Content: "hi"}
+
+	// toolCallIDs extracts tool_call_id from each translated role:"tool" message, in order.
+	toolCallIDs := func(msgs []map[string]interface{}) []string {
+		ids := []string{}
+		for _, m := range msgs {
+			if m["role"] == "tool" {
+				id, _ := m["tool_call_id"].(string)
+				ids = append(ids, id)
+			}
+		}
+		return ids
+	}
+
+	tests := []struct {
+		name    string
+		in      []OllamaMessage
+		wantIDs []string // tool_call_id per surviving tool message, in order
+		wantLen int      // total translated messages (detects drops)
+	}{
+		{
+			name:    "identifierless response binds to the actual call id",
+			in:      []OllamaMessage{user, asst(call("call_abc", "bash")), tool("", "", "/home/user")},
+			wantIDs: []string{"call_abc"},
+			wantLen: 3,
+		},
+		{
+			name:    "multiple identifierless responses bind by position",
+			in:      []OllamaMessage{user, asst(call("call_A", "a"), call("call_B", "b")), tool("", "", "ra"), tool("", "", "rb")},
+			wantIDs: []string{"call_A", "call_B"},
+			wantLen: 4,
+		},
+		{
+			name:    "explicit id consumes its slot so the next identifierless response gets the remaining call",
+			in:      []OllamaMessage{user, asst(call("call_A", "a"), call("call_B", "b")), tool("call_A", "", "ra"), tool("", "", "rb")},
+			wantIDs: []string{"call_A", "call_B"},
+			wantLen: 4,
+		},
+		{
+			name: "tool_name binds by function name even out of order",
+			in: []OllamaMessage{user, asst(call("call_A", "get_weather"), call("call_B", "get_time")),
+				tool("", "get_time", "12:00"), tool("", "get_weather", "sunny")},
+			wantIDs: []string{"call_B", "call_A"},
+			wantLen: 4,
+		},
+		{
+			name: "unbindable response after all calls consumed is dropped",
+			in: []OllamaMessage{user, asst(call("call_A", "a")),
+				tool("", "", "ra"), tool("", "", "response to hallucinated call")},
+			wantIDs: []string{"call_A"},
+			wantLen: 3,
+		},
+		{
+			name: "stale round does not capture a later orphan response",
+			in: []OllamaMessage{user, asst(call("call_A", "a")), tool("call_A", "", "ra"),
+				{Role: "assistant", Content: "done"}, tool("", "", "orphan")},
+			wantIDs: []string{"call_A"},
+			wantLen: 4,
+		},
+		{
+			name:    "named response with no pending calls keeps a synthetic id",
+			in:      []OllamaMessage{user, tool("", "foo", "x")},
+			wantIDs: []string{"call_foo_1"},
+			wantLen: 2,
+		},
+		{
+			name:    "explicit ids are always preserved verbatim",
+			in:      []OllamaMessage{user, asst(call("call_A", "a")), tool("call_XYZ", "", "ra")},
+			wantIDs: []string{"call_XYZ"},
+			wantLen: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := ollamaMessagesToOpenAI(tt.in)
+			assert.Len(t, out, tt.wantLen)
+			assert.Equal(t, tt.wantIDs, toolCallIDs(out))
+		})
+	}
+}

--- a/proxy/ollama_api_tool_flow_test.go
+++ b/proxy/ollama_api_tool_flow_test.go
@@ -575,6 +575,90 @@ func TestZedStyleToolCalls(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code, "Response body: %s", w.Body.String())
 	})
 
+	t.Run("ToolResponseWithoutIdentifiers", func(t *testing.T) {
+		// Some clients send tool responses without tool_name or tool_call_id
+		// These should be matched to pending tool calls by position
+		rawJSON := `{
+			"model": "test-model",
+			"stream": false,
+			"messages": [
+				{"role": "user", "content": "what directory?"},
+				{
+					"role": "assistant",
+					"content": "",
+					"tool_calls": [
+						{"id": "call_abc", "type": "function", "function": {"name": "bash", "arguments": {"command": "pwd"}}}
+					]
+				},
+				{"role": "tool", "content": "/home/user"}
+			],
+			"tools": [
+				{
+					"type": "function",
+					"function": {
+						"name": "bash",
+						"description": "Run command",
+						"parameters": {"type": "object", "properties": {"command": {"type": "string"}}}
+					}
+				}
+			]
+		}`
+
+		httpReq := httptest.NewRequest("POST", "/api/chat", bytes.NewBufferString(rawJSON))
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httpReq
+
+		pm.ollamaChatHandler()(c)
+
+		// Should succeed - tool response matched to pending tool call by position
+		assert.Equal(t, http.StatusOK, w.Code, "Response body: %s", w.Body.String())
+	})
+
+	t.Run("MultipleToolResponsesWithoutIdentifiers", func(t *testing.T) {
+		// Multiple tool calls and responses without explicit identifiers
+		rawJSON := `{
+			"model": "test-model",
+			"stream": false,
+			"messages": [
+				{"role": "user", "content": "check directory and list files"},
+				{
+					"role": "assistant",
+					"content": "",
+					"tool_calls": [
+						{"id": "call_1", "type": "function", "function": {"name": "bash", "arguments": {"command": "pwd"}}},
+						{"id": "call_2", "type": "function", "function": {"name": "bash", "arguments": {"command": "ls"}}}
+					]
+				},
+				{"role": "tool", "content": "/home/user"},
+				{"role": "tool", "content": "file1.txt\nfile2.txt"}
+			],
+			"tools": [
+				{
+					"type": "function",
+					"function": {
+						"name": "bash",
+						"description": "Run command",
+						"parameters": {"type": "object", "properties": {"command": {"type": "string"}}}
+					}
+				}
+			]
+		}`
+
+		httpReq := httptest.NewRequest("POST", "/api/chat", bytes.NewBufferString(rawJSON))
+		httpReq.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+		c.Request = httpReq
+
+		pm.ollamaChatHandler()(c)
+
+		// Should succeed - tool responses matched to pending tool calls by position
+		assert.Equal(t, http.StatusOK, w.Code, "Response body: %s", w.Body.String())
+	})
 }
 
 // TestStreamingToolCallAccumulation tests that tool calls streamed incrementally


### PR DESCRIPTION
## Problem

Some clients (Zed among them) send `role: "tool"` messages with neither `tool_call_id` nor `tool_name`. Currently:

- `validateToolRequest` silently drops these messages, so the model never sees its own tool results and re-calls the tool or hallucinates an answer.
- Responses carrying only `tool_name` get a synthetic `call_<name>_<i>` ID that never matches the assistant's actual tool call IDs, which strict jinja chat templates reject or mispair.

## Fix

Track the most recent assistant message's tool calls during Ollama→OpenAI translation and bind tool responses to them in priority order:

1. explicit `tool_call_id` (verbatim, and it consumes its pending slot so a later identifier-less response can't re-use it)
2. matching function name — pairs correctly even when responses arrive out of order
3. first unconsumed call by position

Responses that cannot be bound to any call (e.g. answers to hallucinated calls that were filtered out) are dropped, since a tool message without `tool_call_id` is invalid under the OpenAI schema — same net behavior as the old filter for that case. The pending list resets on every assistant message so a stale round can never capture a later response.

## Testing

- New table-driven unit tests over `ollamaMessagesToOpenAI` assert the exact `tool_call_id` binding for 8 scenarios (single/multiple identifier-less, mixed explicit+implicit, out-of-order by name, orphan dropping, stale rounds, synthetic fallback). 6 of 8 fail without this change.
- Full `./proxy` suite passes (except the pre-existing `TestProxyManager_ApiGetVersion` ldflags failure, which also fails on clean `main`).
- Running in production on my k3s inference box: verified end-to-end via `/api/chat` that an identifier-less tool response round-trips and the model uses the tool result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)